### PR TITLE
Enhance graph UI and add basic tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,12 @@
         <input type="file" id="files" multiple accept=".txt,application/pdf">
         <input type="password" id="apiKey" placeholder="OpenAI API Key">
         <button id="generate">Generate Graph</button>
+        <input type="text" id="search" placeholder="Search">
+        <select id="categoryFilter">
+            <option value="">All Categories</option>
+        </select>
     </div>
+    <div id="status"></div>
     <div id="graph"></div>
     <div id="summary"></div>
 </div>

--- a/style.css
+++ b/style.css
@@ -30,7 +30,9 @@ body {
 }
 
 input[type="password"],
-input[type="file"] {
+input[type="file"],
+input[type="text"],
+select {
     padding: 8px;
     border: 1px solid #ccc;
     border-radius: 4px;
@@ -63,6 +65,12 @@ button:hover {
     background: #f8f9fa;
     border-radius: 4px;
     line-height: 1.4;
+}
+
+#status {
+    margin-top: 10px;
+    font-style: italic;
+    color: #555;
 }
 
 svg {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const {tokenize, computeTfIdf, cosineSimilarity, buildGraph} = require('../script.js');
+
+function testTfIdf() {
+  const docs = [
+    {name: 'a.txt', text: 'hello world'},
+    {name: 'b.txt', text: 'hello there world'}
+  ];
+  computeTfIdf(docs);
+  assert(docs[0].vector.hasOwnProperty('hello'));
+  const sim = cosineSimilarity(docs[0].vector, docs[1].vector);
+  assert(Number.isFinite(sim));
+}
+
+function testBuildGraph() {
+  const docs = [
+    {name: 'doc1', text: 'text one', categories: ['x'], summary: 's1'},
+    {name: 'doc2', text: 'text two', categories: ['x','y'], summary: 's2'}
+  ];
+  const graph = buildGraph(docs);
+  assert(graph.nodes.length >= 4);
+  assert(graph.links.length >= 2);
+}
+
+testTfIdf();
+testBuildGraph();
+console.log('All tests passed.');
+


### PR DESCRIPTION
## Summary
- add search box, category filter and status area in the UI
- style new inputs and status field
- compute TF-IDF vectors to link similar documents
- add filtering logic and API key persistence
- include simple Node-based unit tests

## Testing
- `node tests/test.js`

------
https://chatgpt.com/codex/tasks/task_e_686cc5fd4dd88327a051b3d1bff3755e