### PR TITLE
Fix missing Babel script

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.min.js"></script>
+    <!-- Babel is required to transpile JSX in the browser -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="app.jsx" type="text/babel"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include Babel standalone script in index.html for JSX transformation

## Testing
- `node tests/test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ccbf9817083278877cf9fd343a15e