### PR TITLE
Fix PDF worker configuration

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -25,6 +25,12 @@ function readPdfFile(file) {
   });
 }
 
+// configure pdf.js worker when running in the browser
+if (typeof pdfjsLib !== 'undefined' && pdfjsLib.GlobalWorkerOptions) {
+  pdfjsLib.GlobalWorkerOptions.workerSrc =
+    'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.worker.min.js';
+}
+
 async function summarize(text, apiKey) {
   const body = {
     model: 'gpt-3.5-turbo',


### PR DESCRIPTION
## Summary
- configure PDF.js worker source so PDF parsing works in the browser

## Testing
- `node tests/test.js`


------
https://chatgpt.com/codex/tasks/task_e_686cd0e7d87083279893774622f9b938